### PR TITLE
fixed trace_tool/src/Main.cpp compilation error in ubuntu-latest docker image

### DIFF
--- a/tool/trace_tool/src/Main.cpp
+++ b/tool/trace_tool/src/Main.cpp
@@ -6,6 +6,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <iomanip> // for std::put_time
 
 using minecpp::nbt::CompoundContent;
 


### PR DESCRIPTION
Compilation was failing with the below error message on ubuntu-latest docker image after doing the apt updates & upgrades:

```
error: no member named 'put_time' in namespace 'std'
   return std::put_time(std::localtime(&c_time), "%FT%T%z");
```